### PR TITLE
Textmate fixes

### DIFF
--- a/syntaxes/samt.tmLanguage.json
+++ b/syntaxes/samt.tmLanguage.json
@@ -117,13 +117,14 @@
 			]
 		},
 		"type-alias": {
+			"name": "meta.typealias.samt",
 			"begin": "(?<!\\^)\\b(alias)\\b",
 			"beginCaptures": {
 				"1": {
 					"name": "storage.type.typealias.samt"
 				}
 			},
-			"end": ":",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"include": "#code"
@@ -142,7 +143,7 @@
 					"name": "storage.type.record.samt"
 				}
 			},
-			"end": "}",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"begin": "(?<=\\brecord\\b)",
@@ -171,8 +172,9 @@
 					]
 				},
 				{
+					"name": "meta.record.body.samt",
 					"begin": "{",
-					"end": "(?=})",
+					"end": "}",
 					"patterns": [
 						{
 							"include": "#code"
@@ -555,6 +557,7 @@
 			"match": "\\b\\d+(\\.\\d+)?[a-zA-Z_]\\w*\\b"
 		},
 		"type": {
+			"name": "meta.type.samt",
 			"comment": "types are usually declared after colons",
 			"begin": ":",
 			"end": "\\b\\w+\\b",

--- a/syntaxes/samt.tmLanguage.json
+++ b/syntaxes/samt.tmLanguage.json
@@ -172,7 +172,6 @@
 					]
 				},
 				{
-					"name": "meta.record.body.samt",
 					"begin": "{",
 					"end": "}",
 					"patterns": [
@@ -557,18 +556,21 @@
 			"match": "\\b\\d+(\\.\\d+)?[a-zA-Z_]\\w*\\b"
 		},
 		"type": {
-			"name": "meta.type.samt",
 			"comment": "types are usually declared after colons",
 			"begin": ":",
-			"end": "\\b\\w+\\b",
+			"end": "(\\b\\w+\\b)|(?=[},\\):])",
 			"endCaptures": {
-				"0": {
+				"1": {
 					"name": "entity.name.type.samt"
 				}
 			},
 			"patterns": [
 				{
 					"include": "#code"
+				}, 
+				{
+					"name": "entity.name.type.samt",
+					"match": "\\b\\w+\\b"
 				}
 			]
 		},

--- a/syntaxes/samt.tmLanguage.json
+++ b/syntaxes/samt.tmLanguage.json
@@ -146,8 +146,8 @@
 			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
 			"patterns": [
 				{
-					"begin": "(?<=\\brecord\\b)",
-					"end": "(?=(\\b(extends)\\b))|(?={)",
+					"begin": "(?<!\\^)(?<=\\brecord\\b)",
+					"end": "((?!\\^)(?=(\\b(extends)\\b)))|(?={)",
 					"patterns": [
 						{
 							"include": "#code"
@@ -159,7 +159,7 @@
 					]
 				},
 				{
-					"begin": "(?<=\\bextends\\b)",
+					"begin": "(?<!\\^)(?<=\\bextends\\b)",
 					"end": "(?={)",
 					"patterns": [
 						{

--- a/syntaxes/samt.tmLanguage.json
+++ b/syntaxes/samt.tmLanguage.json
@@ -66,11 +66,11 @@
 					"name": "keyword.other.import.samt"
 				}
 			},
-			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|enum|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"begin": "(?<!\\^)(?<=\\b(as)\\b)",
-					"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
+					"end": "(?!\\^)(?=\\b(import|package|alias|record|enum|service|provide|consume)\\b)",
 					"patterns": [
 						{
 							"include": "#code"
@@ -105,7 +105,7 @@
 					"name": "keyword.other.package.samt"
 				}
 			},
-			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|enum|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"include": "#code"
@@ -124,7 +124,7 @@
 					"name": "storage.type.typealias.samt"
 				}
 			},
-			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|enum|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"include": "#code"
@@ -143,7 +143,7 @@
 					"name": "storage.type.record.samt"
 				}
 			},
-			"end": "(?!\\^)(?=\\b(import|package|alias|record|service|provide|consume)\\b)",
+			"end": "(?!\\^)(?=\\b(import|package|alias|record|enum|service|provide|consume)\\b)",
 			"patterns": [
 				{
 					"begin": "(?<!\\^)(?<=\\brecord\\b)",

--- a/syntaxes/samt.tmLanguage.json
+++ b/syntaxes/samt.tmLanguage.json
@@ -558,7 +558,7 @@
 		"type": {
 			"comment": "types are usually declared after colons",
 			"begin": ":",
-			"end": "(\\b\\w+\\b)|(?=[},\\):])",
+			"end": "(\\b[_A-Za-z]\\w*\\b)|(?=[},\\):]|\\b\\d)",
 			"endCaptures": {
 				"1": {
 					"name": "entity.name.type.samt"


### PR DESCRIPTION
- Adjustments for the possibility of records without a body
- Leaving the type scope when certain characters are encountered improves syntax highlighting in edge cases
- On some keywords matches, checking for the preceding '^' character was forgotten